### PR TITLE
[Bugfix] instant ammotype changing fix

### DIFF
--- a/code/engine.vc2008/xrGame/WeaponMagazined.cpp
+++ b/code/engine.vc2008/xrGame/WeaponMagazined.cpp
@@ -198,7 +198,7 @@ bool CWeaponMagazined::TryReload()
 			m_pCurrentAmmo = smart_cast<CWeaponAmmo*>(m_pInventory->GetAny( m_ammoTypes[i].c_str() ));
 			if(m_pCurrentAmmo) 
 			{ 
-				m_ammoType			= i; 
+				m_set_next_ammoType_on_reload = i; 
 				SetPending			(TRUE);
 				SwitchState			(eReload);
 				return				true;


### PR DESCRIPTION
When you try to reload weapon but count of ammos in your inventory is not enought for full magazine, ammo's icon automatically changes to an icon of another ammotype.
Also the bug could lead to another kind of behavior. Take into your hands a weapon with not full mag and without ammo of current ammo type in the inventory. Start reloading it and (without waiting for finish of reloading) drop the weapon. Then take it back to the hands. Changing of ammotype would be broken.